### PR TITLE
BSA snapshot functions

### DIFF
--- a/examples/bsa_snapshot.ipynb
+++ b/examples/bsa_snapshot.ipynb
@@ -1,0 +1,545 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "06bec664",
+   "metadata": {},
+   "source": [
+    "# BSA Data Extraction\n",
+    "\n",
+    "LCLS-Live provides simple functions to extract beam synchronous acquisition (BSA) data from archived HDF5 files. These files are stored on SLAC systems, and the user must have access to these to use these functions.\n",
+    "\n",
+    "\n",
+    "See the documentation: LCLS BEAM SYNCHRONOUS DATASTORE USER GUIDE at:\n",
+    "    https://www.slac.stanford.edu/grp/ad/docs/model/matlab/bsd.html\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9af0cd57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9609223",
+   "metadata": {},
+   "source": [
+    "## BSA snapshots\n",
+    "\n",
+    "This is the basic high-level function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "95ce6a19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lcls_live.bsa import bsa_snapshot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1a4aba97",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mbsa_snapshot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimestamp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbeampath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpvnames\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Extract as a snapshot (PV values) nearest a timestamp from a BSA HDF5 file.\n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "h5file: str\n",
+       "    BSA HDF5 file with data that includes the timestamp\n",
+       "    \n",
+       "timestamp: pd.DateTime or datetime.datetime\n",
+       "    This must be localized (not naive time)\n",
+       "    \n",
+       "pvnames : list or None\n",
+       "    List of PV names to extract. If None, all PVs in the source file will be extracted.\n",
+       "    Optional, default=None\n",
+       "    \n",
+       "Returns\n",
+       "-------\n",
+       "snapshot: dict\n",
+       "    Dict with:\n",
+       "        'pvdata' : dict of {pv name:pv value}\n",
+       "        'timestamp' : pd.Timestamp, including the nanosecond.\n",
+       "        'source' : Original HDF5 file that the data came from.\n",
+       "\n",
+       "Examples\n",
+       "--------\n",
+       ">>>bsa_snapshot('2021-11-11T00:00:00-08:00', 'cu_hxr')\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/GitHub/lcls-live/lcls_live/bsa.py\n",
+       "\u001b[0;31mType:\u001b[0m      function\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "?bsa_snapshot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1acc39d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 439 ms, sys: 38.6 ms, total: 478 ms\n",
+      "Wall time: 1.28 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['pvdata', 'timestamp', 'source'])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "snapshot = bsa_snapshot('2021-12-11T00:00:00-08:00', 'cu_hxr')\n",
+    "\n",
+    "snapshot.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2549e239",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1091"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The data is a simple dict\n",
+    "pvdata = snapshot['pvdata']\n",
+    "len(pvdata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2ebb1a52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['ACCL_IN20_300_L0A_A',\n",
+       " 'ACCL_IN20_300_L0A_P',\n",
+       " 'ACCL_IN20_400_L0B_A',\n",
+       " 'ACCL_IN20_400_L0B_P',\n",
+       " 'ACCL_LI21_180_L1X_A',\n",
+       " 'ACCL_LI21_180_L1X_P',\n",
+       " 'ACCL_LI21_1_L1S_A',\n",
+       " 'ACCL_LI21_1_L1S_P',\n",
+       " 'BLD_SYS0_500_ANG_X',\n",
+       " 'BLD_SYS0_500_ANG_Y']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Here are a few keys in the dict\n",
+    "list(pvdata)[0:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "664403fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ACCL_IN20_300_L0A_A 57.99538201588009\n",
+      "ACCL_IN20_300_L0A_P -0.00917495265120749\n",
+      "ACCL_IN20_400_L0B_A 69.47708616061887\n",
+      "ACCL_IN20_400_L0B_P -2.564164251349297\n",
+      "ACCL_LI21_180_L1X_A 21.016761493860674\n",
+      "ACCL_LI21_180_L1X_P -160.00175793392177\n",
+      "ACCL_LI21_1_L1S_A 111.53502637024258\n",
+      "ACCL_LI21_1_L1S_P -22.394640079900164\n",
+      "BLD_SYS0_500_ANG_X -0.03628770291941744\n",
+      "BLD_SYS0_500_ANG_Y -0.0050121151142197545\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And some values\n",
+    "for k in list(pvdata)[0:10]:\n",
+    "    print(k, pvdata[k])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "082f43bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Timestamp('2021-12-11 08:00:00.003286466+0000', tz='UTC')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This is the exact time the data is at\n",
+    "snapshot['timestamp']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "55958223",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/gpfs/slac/staas/fs1/g/bsd/BSAService/data/2021/12/11/CU_HXR_20211211_080825.h5'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# And the original HDF5 source file\n",
+    "snapshot['source']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8dc1f64d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(nan)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Note that some values are nan\n",
+    "pvdata['BLM_UNDH_0235_QDCRAW']    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cc475fdf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'pvdata': {'ACCL_IN20_300_L0A_A': array(57.99538202),\n",
+       "  'ACCL_IN20_300_L0A_P': array(-0.00917495),\n",
+       "  'dummy': None},\n",
+       " 'timestamp': Timestamp('2021-12-11 08:00:00.003286466+0000', tz='UTC'),\n",
+       " 'source': '/gpfs/slac/staas/fs1/g/bsd/BSAService/data/2021/12/11/CU_HXR_20211211_080825.h5'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Adding a list pv names to be extracted. Note that any PV not present is simply returned as None\n",
+    "bsa_snapshot('2021-12-11T00:00:00-08:00', 'cu_hxr', \n",
+    "             pvnames = ['ACCL_IN20_300_L0A_A', 'ACCL_IN20_300_L0A_P', 'dummy'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdde97cc",
+   "metadata": {},
+   "source": [
+    "## Notes on timestamps\n",
+    "\n",
+    "Timestamps here must have localization information (i.e. the time zone). Otherwise it is ambiguous what time to extract. The internal data files and directories are named and described in UTC time only.\n",
+    "\n",
+    "See: https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.html\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "34050f32",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cannot convert tz-naive Timestamp, use tz_localize to localize\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The timestamp must be localized, so this will fail:\n",
+    "try:\n",
+    "    bsa_snapshot('2021-12-11T00:00:00', 'cu_hxr')\n",
+    "except Exception as ex:\n",
+    "    print(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ea6f3e1a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2021, 12, 1, 17, 7, 49)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import datetime\n",
+    "# This is not localized:\n",
+    "datetime.datetime(2021, 12, 1, 17, 7, 49)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "eb317aed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2021, 12, 1, 17, 7, 49, tzinfo=datetime.timezone.utc)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# but this is:\n",
+    "dtime = datetime.datetime(2021, 12, 1, 17, 7, 49, tzinfo=datetime.timezone.utc)\n",
+    "dtime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a82a98b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Timestamp('2021-12-01 17:07:49.002202872+0000', tz='UTC')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# And will work with bsa_snapshot\n",
+    "bsa_snapshot(dtime, 'cu_hxr')['timestamp']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbd6907b",
+   "metadata": {},
+   "source": [
+    "## Helper functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "389d8842",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lcls_live.bsa import bsa_h5file, BSA_DATA_SEARCH_PATHS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1ae49924",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['/gpfs/slac/staas/fs1/g/bsd/BSAService/data/',\n",
+       " '/nfs/slac/g/bsd/BSAService/data/']"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# These are the pahs searched.\n",
+    "BSA_DATA_SEARCH_PATHS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "bd0f8909",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/gpfs/slac/staas/fs1/g/bsd/BSAService/data/2021/12/11/CU_HXR_20211211_080825.h5'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find the appropriate file\n",
+    "bsa_h5file('2021-12-11T00:00:00-08:00', 'cu_hxr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "372c9999",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mbsa_h5file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimestamp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbeampath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Finds the BSA HDF5 file that contains the timestamp for a given beampath\n",
+       "\n",
+       "BSA data files are named as:\n",
+       "    CU_SXR_20211210_140742.h5\n",
+       "    \n",
+       "Which corresponds to '{beampath}_{time_str}.h5' with time_str in the format: '%Y%m%d_%H%M%S'\n",
+       "    \n",
+       "See the documentation in:\n",
+       "    https://www.slac.stanford.edu/grp/ad/docs/model/matlab/bsd.html\n",
+       "     \"The data files are named with the UTC datestamp of the END of their data taking period\"\n",
+       "     \n",
+       "Parameters\n",
+       "----------\n",
+       "\n",
+       "timestamp: pd.DateTime or datetime.datetime\n",
+       "    This must be localized (not naive time)\n",
+       "\n",
+       "beampath : str\n",
+       "        one of ['cu_hxr', 'cu_sxr'] (case independent)\n",
+       "    \n",
+       "Returns\n",
+       "-------\n",
+       "h5file : str\n",
+       "    Full path to the HDF5 file that should contain the time. \n",
+       "        \n",
+       "        \n",
+       "Examples\n",
+       "--------\n",
+       "\n",
+       ">>> bsa_h5file('2021-12-11T00:00:00-08:00', 'cu_hxr')\n",
+       "'/gpfs/slac/staas/fs1/g/bsd/BSAService/data/2021/12/11/CU_HXR_20211211_080825.h5'\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/GitHub/lcls-live/lcls_live/bsa.py\n",
+       "\u001b[0;31mType:\u001b[0m      function\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "?bsa_h5file"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LCLS-Live",
+   "language": "python",
+   "name": "lcls-live"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lcls_live/bsa.py
+++ b/lcls_live/bsa.py
@@ -38,8 +38,8 @@ def bsa_h5file(timestamp, beampath):
     Parameters
     ----------
     
-    timestamp: pd.DateTime or datetime.datetime
-        This must be localized (not naive time)
+    timestamp: datetime-like, str, int, float
+        This must be localized (not naive time).
     
     beampath : str
             one of ['cu_hxr', 'cu_sxr'] (case independent)
@@ -101,8 +101,8 @@ def extract_pvdata(h5file, timestamp, pvnames=None):
     h5file: str
         BSA HDF5 file with data that includes the timestamp
         
-    timestamp: pd.DateTime or similar
-        This must be localized (not naive time)
+    timestamp: datetime-like, str, int, float
+        This must be localized (not naive time).
     
     Returns
     -------
@@ -161,12 +161,10 @@ def bsa_snapshot(timestamp, beampath, pvnames=None):
     Extract as a snapshot (PV values) nearest a timestamp from a BSA HDF5 file.
     
     Parameters
-    ----------
-    h5file: str
-        BSA HDF5 file with data that includes the timestamp
+    ----------        
+    timestamp: datetime-like, str, int, float
+        This must be localized (not naive time).
         
-    timestamp: pd.DateTime or datetime.datetime
-        This must be localized (not naive time)
         
     pvnames : list or None
         List of PV names to extract. If None, all PVs in the source file will be extracted.
@@ -179,6 +177,11 @@ def bsa_snapshot(timestamp, beampath, pvnames=None):
             'pvdata' : dict of {pv name:pv value}
             'timestamp' : pd.Timestamp, including the nanosecond.
             'source' : Original HDF5 file that the data came from.
+           
+    Notes
+    -----
+    timestamp will be cast to a pd.Timestamp internally.
+    See: https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.html
     
     Examples
     --------

--- a/lcls_live/bsa.py
+++ b/lcls_live/bsa.py
@@ -1,0 +1,201 @@
+import pandas as pd
+import h5py
+import numpy as np
+import datetime
+import os
+
+
+BSA_DATA_SEARCH_PATHS = ['/gpfs/slac/staas/fs1/g/bsd/BSAService/data/',
+                        '/nfs/slac/g/bsd/BSAService/data/'       
+                        ]
+
+
+
+def get_bsa_data_path():
+    for d in BSA_DATA_SEARCH_PATHS:
+        if os.path.exists(d):
+            return d
+    raise ValueError(f'Cannot find BSA data path. Searched: {BSA_DATA_SEARCH_PATHS}')
+    
+def bsa_h5file_end_time(filename):    
+    time_str  =  os.path.splitext(os.path.split(filename)[1])[0][-15:]
+    naive_time = datetime.datetime.strptime(time_str, '%Y%m%d_%H%M%S')          
+    return pd.Timestamp(naive_time, tz='UTC')
+    
+def bsa_h5file(timestamp, beampath):
+    """    
+    Finds the BSA HDF5 file that contains the timestamp for a given beampath
+    
+    BSA data files are named as:
+        CU_SXR_20211210_140742.h5
+        
+    Which corresponds to '{beampath}_{time_str}.h5' with time_str in the format: '%Y%m%d_%H%M%S'
+        
+    See the documentation in:
+        https://www.slac.stanford.edu/grp/ad/docs/model/matlab/bsd.html
+         "The data files are named with the UTC datestamp of the END of their data taking period"
+         
+    Parameters
+    ----------
+    
+    timestamp: pd.DateTime or datetime.datetime
+        This must be localized (not naive time)
+    
+    beampath : str
+            one of ['cu_hxr', 'cu_sxr'] (case independent)
+        
+    Returns
+    -------
+    h5file : str
+        Full path to the HDF5 file that should contain the time. 
+            
+            
+    Examples
+    --------
+    
+    >>> bsa_h5file('2021-12-11T00:00:00-08:00', 'cu_hxr')
+    '/gpfs/slac/staas/fs1/g/bsd/BSAService/data/2021/12/11/CU_HXR_20211211_080825.h5'
+    
+    
+    
+    """
+    
+    timestamp = pd.Timestamp(timestamp).tz_convert('UTC') # Convert to UTC
+    
+    # Files should be prefixed with upper case beampaths
+    beampath = beampath.upper()
+    
+    # Strings with zero padding
+    year =  str(timestamp.year)
+    month = f'{timestamp.month:02}'
+    day = f'{timestamp.day:02}'
+    
+    # All h5 files should be in here
+    root = get_bsa_data_path()
+    
+    # This is the nearest path
+    path = os.path.join(root, year, month , day )
+    
+    # Find the file
+    files = [f for f in os.listdir(path) if f.startswith(beampath) and f.endswith('.h5')]
+    times = list(map(bsa_h5file_end_time, files))
+    found = False
+    for time, file in sorted(zip(times, files)):
+        if  time > timestamp:
+            found = True
+            #print('FOUND', time, timestamp)
+            break
+    if not found:
+        raise ValueError(f'Could not find BSA file containing {timestamp} in {path}')
+        
+    return os.path.join(path, file)
+
+
+
+def extract_pvdata(h5file, timestamp, pvnames=None):
+    """
+    Extract as a snapshot (PV values) nearest a timestamp from a BSA HDF5 file.
+    
+    Parameters
+    ----------
+    h5file: str
+        BSA HDF5 file with data that includes the timestamp
+        
+    timestamp: pd.DateTime or similar
+        This must be localized (not naive time)
+    
+    Returns
+    -------
+    pvdata: dict
+        Dict of pvname:value
+    
+    found_timestamp : pd.Timestamp
+        The exact time that the data was tagged at
+        
+            
+    See Also
+    --------        
+    bsa_snapshot
+    
+    
+    """
+    
+    timestamp = pd.Timestamp(timestamp).tz_convert('UTC') # Convert to UTC    
+    
+    with h5py.File(h5file) as h5:
+        
+        # Use pandas to get the nearest time
+        s = h5['secondsPastEpoch'][:, 0]
+        ns = h5['nanoseconds'][:, 0]
+        df = pd.DataFrame({'s':s, 'ns':ns})
+        df['time'] = pd.to_datetime(df['s'], unit='s', utc=True) + pd.to_timedelta(df['ns'], unit='nanoseconds')
+        
+        # Assure that the time is in here
+        assert timestamp <= df.time.iloc[-1]
+        assert timestamp >= df.time.iloc[0]
+        
+        # Search for the nearest time
+        ix = df.time.searchsorted(timestamp)
+        found_timestamp = df['time'].iloc[ix]
+        
+        # form snapshot dict
+        pvdata = {}
+    
+        # Return everything
+        if pvnames is None:
+            pvnames = list(h5)
+    
+        for pvname in pvnames:
+            if pvname in h5:
+                pvdata[pvname] = np.squeeze(h5[pvname][ix])
+            else:
+                pvdata[pvname] = None
+
+    return pvdata, found_timestamp
+
+
+
+
+def bsa_snapshot(timestamp, beampath, pvnames=None):
+    """
+    Extract as a snapshot (PV values) nearest a timestamp from a BSA HDF5 file.
+    
+    Parameters
+    ----------
+    h5file: str
+        BSA HDF5 file with data that includes the timestamp
+        
+    timestamp: pd.DateTime or datetime.datetime
+        This must be localized (not naive time)
+        
+    pvnames : list or None
+        List of PV names to extract. If None, all PVs in the source file will be extracted.
+        Optional, default=None
+        
+    Returns
+    -------
+    snapshot: dict
+        Dict with:
+            'pvdata' : dict of {pv name:pv value}
+            'timestamp' : pd.Timestamp, including the nanosecond.
+            'source' : Original HDF5 file that the data came from.
+    
+    Examples
+    --------
+    >>>bsa_snapshot('2021-11-11T00:00:00-08:00', 'cu_hxr')
+    
+    """    
+    h5file = bsa_h5file(timestamp, beampath)
+    pvdata, found_timestamp = extract_pvdata(h5file, timestamp, pvnames=pvnames)
+    
+    snapshot = {}
+    snapshot['pvdata'] = pvdata
+    snapshot['timestamp'] = found_timestamp
+    snapshot['source'] = h5file
+    
+    return snapshot
+
+
+
+
+


### PR DESCRIPTION
Added high level functions to fetch BSA data from archived HDF5 files. 

This finds the appropriate HDF5 file and extracts the data nearest the given timestamp:
```python
from lcls_live.bsa import bsa_snapshot
bsa_snapshot('2021-12-11T00:00:00-08:00', 'cu_hxr')
```
