### PR TITLE
Do not use 1H suffix for SC linac BPMs.

### DIFF
--- a/lcls_live/datamaps/builders.py
+++ b/lcls_live/datamaps/builders.py
@@ -35,7 +35,11 @@ def build_bpm_dm(tao, model):
         suffix = 'CUS1H' # 1 Hz
     elif model == 'cu_spec':
         suffix = '1H'
-    elif model.startswith('sc'):
+    elif model == 'sc_hxr':
+        suffix = 'SCH1H'
+    elif model == 'sc_sxr':
+        suffix = 'SCS1H'
+    elif model == 'sc_bsyd' or model == 'sc_diag0':
         suffix = ''
     else:
         suffix = '1H'

--- a/lcls_live/datamaps/builders.py
+++ b/lcls_live/datamaps/builders.py
@@ -35,6 +35,8 @@ def build_bpm_dm(tao, model):
         suffix = 'CUS1H' # 1 Hz
     elif model == 'cu_spec':
         suffix = '1H'
+    elif model.startswith('sc'):
+        suffix = ''
     else:
         suffix = '1H'
     


### PR DESCRIPTION
In the SC linac, there is not a general-purpose '1H' suffix for 1 Hz BPM PVs.  For the HXR-destined shots, there's SCH1H.  For SXR-destined shots, there's SCS1H.  There's no suffix at all for the SC_BSYD line, or SC_DIAG0.