### PR TITLE
pin urllib3 to avoid ssl dependency problem with recent urllib 2.0.2 …

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,6 +7,7 @@ dependencies:
   - matplotlib-base
   - pandas
   - requests
+  - urllib3<2
   - pyepics
   - pyyaml
   - pytao

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 # conda env create -f environment.yml
-name: lcls-live-docs
+name: lcls-live
 channels:
   - conda-forge
 dependencies:
@@ -7,6 +7,7 @@ dependencies:
   - matplotlib-base
   - pandas
   - requests
+  - urllib3<2
   - pyepics
   - pyyaml
   - pytao

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3==1.26.15
+urllib3<2
 pandas
 requests
 pyepics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+urllib3==1.26.15
 pandas
 requests
 pyepics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 urllib3<2
+pysocks
 pandas
 requests
 pyepics


### PR DESCRIPTION
urllib3 2.0.2 was recently released on May 3rd.  The new release dependency issues related to openssl and libressh that appear on macos.  This fix is to pin the urllib3 version to 1.26.15 (the most recent before 2.0.2).