### PR TITLE
Remove import that fails in python 3.12

### DIFF
--- a/lcls_live/datamaps/__init__.py
+++ b/lcls_live/datamaps/__init__.py
@@ -1,6 +1,5 @@
 from .klystron import KlystronDataMap
 from .tabular import TabularDataMap
-import imp
 from lcls_live import data_dir
 import json
 import pandas as pd


### PR DESCRIPTION
The imp module no longer exists in python 3.12

`DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses`

But it is safe to just remove the line without replacing it with anything since it wasn't used in this file anymore.
