### PR TITLE
Urllib3 downver

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,11 +3,11 @@ name: lcls-live-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   - matplotlib-base
   - pandas
   - requests
-  - urllib3<2
+  - urllib3>=2.5
   - pyepics
   - pyyaml
   - pytao

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - matplotlib-base
   - pandas
   - requests
-  - urllib3>=2.5
+  - urllib3
   - pyepics
   - pyyaml
   - pytao

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: lcls-live
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   - matplotlib-base
   - pandas
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - matplotlib-base
   - pandas
   - requests
-  - urllib3<2
+  - urllib3
   - pyepics
   - pyyaml
   - pytao

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3<2
+urllib3
 pysocks
 pandas
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3>=2.5
+urllib3
 pysocks
 pandas
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3
+urllib3>=2.5
 pysocks
 pandas
 requests


### PR DESCRIPTION
urllib3 < version 2.5 is flagged for a vulnerability.

Updated python from 3.8 to 3.9, which brings in urllib3 2.5.0 

Note that urllib3 >= 2.5 cannot be met with python 3.8.