### PR TITLE
Update requirements file

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.12']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas
 requests
 pyepics
 pyyaml
-pytao >= 1.0.0
+pytao>=1.0.0


### PR DESCRIPTION
When installing lcls-live from github like this:

https://github.com/slaclab/lcls-python3-envs/blob/7f7471c038d7898fb37e0f6f1b4a3c4e72e7a38d/python3_rhel7_env.yml#L118

Or also just locally like this:

```
$ git clone https://github.com/slaclab/lcls-live.git
$ cd lcls-live
$ pip install .
```

Will get this error:

```
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in lcls-live setup command: 'install_requires' must be a string or iterable of strings containing valid project/version requirement specifiers; Expected package name at the start of dependency specifier
          >=
          ^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
```


Quick change to just remove the spaces around '>=' in requirements.txt so pip can install correctly.

Also updates the python version in the documentation job to get it working again.
